### PR TITLE
Add main sidebar layout structure

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 import { ThemeProvider } from "@/components/theme-provider";
+import { MainSidebar } from "@/components/MainSidebar";
 
 import "./globals.css";
 import { SessionProvider } from "next-auth/react";
@@ -79,7 +80,12 @@ export default function RootLayout({
           enableSystem
         >
           <Toaster position="top-center" />
-          <SessionProvider>{children}</SessionProvider>
+          <SessionProvider>
+            <div className="flex h-screen overflow-hidden">
+              <MainSidebar />
+              <main className="flex flex-1 overflow-hidden">{children}</main>
+            </div>
+          </SessionProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/components/MainSidebar.tsx
+++ b/components/MainSidebar.tsx
@@ -100,7 +100,7 @@ function NavigationSection({
 
 export function MainSidebar() {
   return (
-    <aside className="flex h-full w-72 flex-col border-r bg-background px-5 py-6">
+    <aside className="flex h-full w-64 flex-col border-r bg-background px-5 py-6">
       <div className="flex items-center gap-3 px-2">
         <div className="flex size-10 items-center justify-center rounded-lg bg-primary text-lg font-semibold text-primary-foreground">
           SH


### PR DESCRIPTION
## Summary
- import and render the MainSidebar in the app root layout
- wrap the application body with a flex container so the primary area fills the remaining space
- adjust the MainSidebar component width to a fixed 16rem to align with other sidebars

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1de3103f48325be62635b8e5deb0e