### PR TITLE
Refine root layout sidebar structure

### DIFF
--- a/components/main-sidebar/index.ts
+++ b/components/main-sidebar/index.ts
@@ -1,0 +1,3 @@
+// biome-ignore lint/performance/noBarrelFile: Shared entry point for main sidebar modules
+export { MainSidebar } from "./main-sidebar";
+export { MainSidebarProvider, useMainSidebar } from "./provider";

--- a/components/main-sidebar/provider.tsx
+++ b/components/main-sidebar/provider.tsx
@@ -32,16 +32,31 @@ function getInitialSidebarState() {
   return value !== "false";
 }
 
+type MainSidebarProviderProps = {
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+};
+
 export function MainSidebarProvider({
   children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [open, setOpenState] = React.useState(true);
+  defaultOpen,
+}: MainSidebarProviderProps) {
+  const [open, setOpenState] = React.useState(() => {
+    if (typeof defaultOpen === "boolean") {
+      return defaultOpen;
+    }
+
+    return getInitialSidebarState();
+  });
 
   React.useEffect(() => {
+    if (typeof defaultOpen === "boolean") {
+      setOpenState(defaultOpen);
+      return;
+    }
+
     setOpenState(getInitialSidebarState());
-  }, []);
+  }, [defaultOpen]);
 
   const setOpen = React.useCallback(
     (nextOpen: boolean | ((value: boolean) => boolean)) => {


### PR DESCRIPTION
## Summary
- load sidebar cookie state and session in the root layout to initialize providers consistently on the server
- restructure the root layout body to render the main and app sidebars side by side with a shared inset area
- allow the main sidebar provider to accept a default open state and expose a shared entry point for sidebar components

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1eb64d74883259edf4007ee72db12