### PR TITLE
Simplify chat layout wrapper

### DIFF
--- a/app/(chat)/layout.tsx
+++ b/app/(chat)/layout.tsx
@@ -1,32 +1,16 @@
-import { cookies } from "next/headers";
 import Script from "next/script";
-import { AppSidebar } from "@/components/app-sidebar";
 import { DataStreamProvider } from "@/components/data-stream-provider";
-import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
-import { auth } from "../(auth)/auth";
 
 export const experimental_ppr = true;
 
-export default async function Layout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  const [session, cookieStore] = await Promise.all([auth(), cookies()]);
-  const isCollapsed = cookieStore.get("sidebar_state")?.value !== "true";
-
+export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Script
         src="https://cdn.jsdelivr.net/pyodide/v0.23.4/full/pyodide.js"
         strategy="beforeInteractive"
       />
-      <DataStreamProvider>
-        <SidebarProvider defaultOpen={!isCollapsed}>
-          <AppSidebar user={session?.user} />
-          <SidebarInset>{children}</SidebarInset>
-        </SidebarProvider>
-      </DataStreamProvider>
+      <DataStreamProvider>{children}</DataStreamProvider>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- remove chat segment sidebar logic now handled by the root layout
- keep the pyodide script and data stream provider while rendering chat children directly

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1ed69f438832584310fe487043f44