### PR TITLE
Fix cookie retrieval in RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const mainOpen = cookieStore.get("main_sidebar_state")?.value !== "false";
   const sidebarOpen = cookieStore.get("sidebar_state")?.value !== "false";
   const session = await auth().catch(() => null);


### PR DESCRIPTION
## Summary
- await the Next.js cookie store inside RootLayout so cookies are resolved asynchronously

## Testing
- pnpm build *(fails: POSTGRES_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f0734e508325b55e82d380810d33