### PR TITLE
Add service hub and informational service pages

### DIFF
--- a/app/hub/page.tsx
+++ b/app/hub/page.tsx
@@ -1,0 +1,104 @@
+import { ArrowRight } from "lucide-react";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const services = [
+  {
+    title: "Residenza",
+    description:
+      "Gestisci cambi di residenza, certificati anagrafici e documentazione locale.",
+    href: "/residenza",
+  },
+  {
+    title: "Lavoro",
+    description:
+      "Scopri come ottenere permessi, comprendere i contratti e rispettare la normativa.",
+    href: "/lavoro",
+  },
+  {
+    title: "Impresa",
+    description:
+      "Avvia o gestisci la tua attività con guide su licenze, fisco e adempimenti.",
+    href: "/impresa",
+  },
+  {
+    title: "Immigrazione",
+    description:
+      "Orientati fra visti, permessi di soggiorno e procedure di ricongiungimento familiare.",
+    href: "/immigrazione",
+  },
+  {
+    title: "Pensionati",
+    description:
+      "Accedi a servizi per pensionati esteri, agevolazioni fiscali e trasferimenti di residenza.",
+    href: "/pensionati",
+  },
+];
+
+export const metadata: Metadata = {
+  title: "Hub dei Servizi",
+  description:
+    "Esplora i servizi dedicati a residenza, lavoro, impresa, immigrazione e pensionati.",
+};
+
+export default function HubPage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10">
+        <header className="flex flex-col gap-4">
+          <div className="space-y-2">
+            <p className="font-medium text-muted-foreground text-sm uppercase tracking-wider">
+              Space Hub
+            </p>
+            <h1 className="font-semibold text-3xl tracking-tight">
+              Hub dei Servizi
+            </h1>
+          </div>
+          <p className="max-w-2xl text-muted-foreground">
+            Scegli un ambito per scoprire risorse, linee guida e strumenti
+            pratici. Puoi sempre tornare al chatbot per ottenere supporto
+            personalizzato.
+          </p>
+          <Button asChild className="w-fit">
+            <Link href="/">
+              Apri Chatbot
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        </header>
+
+        <section className="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          {services.map((service) => (
+            <Card className="flex flex-col" key={service.title}>
+              <CardHeader className="flex-1">
+                <CardTitle>{service.title}</CardTitle>
+                <CardDescription>{service.description}</CardDescription>
+              </CardHeader>
+              <CardFooter>
+                <Button
+                  asChild
+                  className="w-full justify-between"
+                  variant="outline"
+                >
+                  <Link href={service.href}>
+                    Esplora servizio
+                    <ArrowRight className="size-4" />
+                  </Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/immigrazione/page.tsx
+++ b/app/immigrazione/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Immigrazione",
+  description:
+    "Orientati fra visti, permessi di soggiorno e procedure di ricongiungimento familiare.",
+};
+
+export default function ImmigrazionePage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="font-semibold text-3xl tracking-tight">Immigrazione</h1>
+        <p className="text-muted-foreground">
+          Orientati fra visti, permessi di soggiorno e procedure di
+          ricongiungimento familiare.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/impresa/page.tsx
+++ b/app/impresa/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Impresa",
+  description:
+    "Avvia o gestisci la tua attività con guide su licenze, fisco e adempimenti.",
+};
+
+export default function ImpresaPage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="font-semibold text-3xl tracking-tight">Impresa</h1>
+        <p className="text-muted-foreground">
+          Avvia o gestisci la tua attività con guide su licenze, fisco e
+          adempimenti.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/lavoro/page.tsx
+++ b/app/lavoro/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Lavoro",
+  description:
+    "Scopri come ottenere permessi, comprendere i contratti e rispettare la normativa.",
+};
+
+export default function LavoroPage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="font-semibold text-3xl tracking-tight">Lavoro</h1>
+        <p className="text-muted-foreground">
+          Scopri come ottenere permessi, comprendere i contratti e rispettare la
+          normativa.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/pensionati/page.tsx
+++ b/app/pensionati/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Pensionati",
+  description:
+    "Accedi a servizi per pensionati esteri, agevolazioni fiscali e trasferimenti di residenza.",
+};
+
+export default function PensionatiPage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="font-semibold text-3xl tracking-tight">Pensionati</h1>
+        <p className="text-muted-foreground">
+          Accedi a servizi per pensionati esteri, agevolazioni fiscali e
+          trasferimenti di residenza.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/residenza/page.tsx
+++ b/app/residenza/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Residenza",
+  description:
+    "Gestisci cambi di residenza, certificati anagrafici e documentazione locale.",
+};
+
+export default function ResidenzaPage() {
+  return (
+    <div className="h-full overflow-y-auto p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <h1 className="font-semibold text-3xl tracking-tight">Residenza</h1>
+        <p className="text-muted-foreground">
+          Gestisci cambi di residenza, certificati anagrafici e documentazione
+          locale.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a public-facing service hub page with cards linking to key assistance areas and a chatbot shortcut
- create standalone residenza, lavoro, impresa, immigrazione, and pensionati routes with matching metadata

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e200a31c988325bff7c379466f6d0e